### PR TITLE
Limit Travis CI build types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+if: (branch = master) OR (type = pull_request)
 language: csharp
 mono: none
 dotnet: 2.1.700


### PR DESCRIPTION
Try different Travis CI config. Trying to limit builds to PR and merges to `master`. I push to branches a lot. They don't all need to be built.