### PR TITLE
Fix/minor design refactor

### DIFF
--- a/BoringHelpers/BoringHelpers.csproj
+++ b/BoringHelpers/BoringHelpers.csproj
@@ -3,15 +3,15 @@
   <PropertyGroup>
     <TargetFramework>netstandard1.4</TargetFramework>
     <Authors>Benjamin Cronce</Authors>
-    <Version>0.0.1.1</Version>
+    <Version>0.1.0.0</Version>
     <Copyright>Copyright ©2019 Benjamin Cronce</Copyright>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/bcronce/BoringHelpers</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bcronce/BoringHelpers</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+    <AssemblyVersion>0.1.0.0</AssemblyVersion>
     <PackageTags>helper efficient netstandard collection</PackageTags>
-    <FileVersion>0.0.1.0</FileVersion>
+    <FileVersion>0.1.0.0</FileVersion>
     <Description>General use library to help make your code cleaner and more efficient.</Description>
   </PropertyGroup>
 

--- a/BoringHelpers/Collections/Individual.cs
+++ b/BoringHelpers/Collections/Individual.cs
@@ -39,13 +39,13 @@ namespace BoringHelpers.Collections
 
         public static ISet<T> Set<T>(T item, IEqualityComparer<T> comparer) => new SingleSet<T>(item, comparer);
 
-        public static IEnumerable<T> ConcatSingle<T>(this IEnumerable<T> left, T single)
+        public static IEnumerable<T> ConcatIndividual<T>(this IEnumerable<T> left, T single)
         {
             foreach (var item in left) yield return item;
             yield return single;
         }
 
-        public static IEnumerable<T> ConcatSingle<T>(this IList<T> left, T single)
+        public static IEnumerable<T> ConcatIndividual<T>(this IList<T> left, T single)
         {
             for(int i = 0; i < left.Count; i++) yield return left[i];
             yield return single;

--- a/BoringHelpers/Collections/Individual.cs
+++ b/BoringHelpers/Collections/Individual.cs
@@ -103,7 +103,7 @@ namespace BoringHelpers.Collections
                 }
             }
 
-            public void Reset() => this.state = State.Reset;
+            public void Reset() => throw new NotSupportedException();
 
             public void Dispose()
             {

--- a/BoringHelpers/Collections/Individual.cs
+++ b/BoringHelpers/Collections/Individual.cs
@@ -13,9 +13,10 @@ namespace BoringHelpers.Collections
 
         public static IReadOnlyList<T> ReadOnlyList<T>(T item, IEqualityComparer<T> comparer) => new SingleList<T>(item, comparer);
 
-        public static IReadOnlyDictionary<TKey, TValue> ReadOnlyDictionary<TKey, TValue>(KeyValuePair<TKey, TValue> item) => new SingleDictionary<TKey, TValue>(item);
+        public static IReadOnlyDictionary<TKey, TValue> ReadOnlyDictionary<TKey, TValue>(TKey key, TValue value) => new SingleDictionary<TKey, TValue>(new KeyValuePair<TKey, TValue>(key, value));
 
-        public static IReadOnlyDictionary<TKey, TValue> ReadOnlyDictionary<TKey, TValue>(KeyValuePair<TKey, TValue> item, IEqualityComparer<TKey> comparer) => new SingleDictionary<TKey, TValue>(item, comparer);
+        public static IReadOnlyDictionary<TKey, TValue> ReadOnlyDictionary<TKey, TValue>(TKey key, TValue value, IEqualityComparer<TKey> comparer)
+            => new SingleDictionary<TKey, TValue>(new KeyValuePair<TKey, TValue>(key, value), comparer);
 
         public static IReadOnlyCollection<T> ReadOnlyCollection<T>(T item) => new SingleCollection<T>(item);
 
@@ -25,9 +26,10 @@ namespace BoringHelpers.Collections
 
         public static IList<T> List<T>(T item, IEqualityComparer<T> comparer) => new SingleList<T>(item, comparer);
 
-        public static IDictionary<TKey, TValue> Dictionary<TKey, TValue>(KeyValuePair<TKey, TValue> item) => new SingleDictionary<TKey, TValue>(item);
+        public static IDictionary<TKey, TValue> Dictionary<TKey, TValue>(TKey key, TValue value) => new SingleDictionary<TKey, TValue>(new KeyValuePair<TKey, TValue>(key, value));
 
-        public static IDictionary<TKey, TValue> Dictionary<TKey, TValue>(KeyValuePair<TKey, TValue> item, IEqualityComparer<TKey> comparer) => new SingleDictionary<TKey, TValue>(item, comparer);
+        public static IDictionary<TKey, TValue> Dictionary<TKey, TValue>(TKey key, TValue value, IEqualityComparer<TKey> comparer)
+            => new SingleDictionary<TKey, TValue>(new KeyValuePair<TKey, TValue>(key, value), comparer);
 
         public static ICollection<T> Collection<T>(T item) => new SingleCollection<T>(item);
 

--- a/BoringHelpers/Collections/Individual.cs
+++ b/BoringHelpers/Collections/Individual.cs
@@ -64,43 +64,19 @@ namespace BoringHelpers.Collections
 
         private class SingleEnumerator<T> : IEnumerator<T>
         {
-            private T item;
-            private State state = State.Reset;
-            private enum State : byte
-            {
-                Reset,
-                Moved,
-                Done
-            }
+            private bool moved = false;
 
-            public SingleEnumerator(T item) => this.item = item;
+            public SingleEnumerator(T item) => this.Current = item;
 
-            public T Current
-            {
-                get
-                {
-                    if (this.state == State.Moved)
-                    {
-                        return this.item;
-                    }
-                    throw new InvalidOperationException("Enumeration has not started. Call MoveNext.");
-                }
-            }
+            public T Current { get; }
 
             object IEnumerator.Current => this.Current;
 
             public bool MoveNext()
             {
-                if (this.state == State.Reset)
-                {
-                    this.state = State.Moved;
-                    return true;
-                }
-                else
-                {
-                    this.state = State.Done;
-                    return false;
-                }
+                if (this.moved) return false;
+                this.moved = true;
+                return true;
             }
 
             public void Reset() => throw new NotSupportedException();

--- a/BoringHelpers/Collections/Individual.cs
+++ b/BoringHelpers/Collections/Individual.cs
@@ -11,16 +11,12 @@ namespace BoringHelpers.Collections
 
         public static IReadOnlyList<T> ReadOnlyList<T>(T item) => new SingleList<T>(item);
 
-        public static IReadOnlyList<T> ReadOnlyList<T>(T item, IEqualityComparer<T> comparer) => new SingleList<T>(item, comparer);
-
         public static IReadOnlyDictionary<TKey, TValue> ReadOnlyDictionary<TKey, TValue>(TKey key, TValue value) => new SingleDictionary<TKey, TValue>(new KeyValuePair<TKey, TValue>(key, value));
 
         public static IReadOnlyDictionary<TKey, TValue> ReadOnlyDictionary<TKey, TValue>(TKey key, TValue value, IEqualityComparer<TKey> comparer)
             => new SingleDictionary<TKey, TValue>(new KeyValuePair<TKey, TValue>(key, value), comparer);
 
         public static IReadOnlyCollection<T> ReadOnlyCollection<T>(T item) => new SingleCollection<T>(item);
-
-        public static IReadOnlyCollection<T> ReadOnlyCollection<T>(T item, IEqualityComparer<T> comparer) => new SingleCollection<T>(item, comparer);
 
         public static IList<T> List<T>(T item) => new SingleList<T>(item);
 

--- a/BoringHelpersTests/Collections/Collection.cs
+++ b/BoringHelpersTests/Collections/Collection.cs
@@ -66,9 +66,61 @@ namespace BoringHelpersTests.Collections
         [InlineData("")]
         [InlineData("foobar")]
         [InlineData("HeLlO wOrLd")]
+        public void Individual_Contains_List(string input)
+        {
+            var collection = Individual.List(input);
+            Assert.True(collection.Contains(input));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("foobar")]
+        [InlineData("HeLlO wOrLd")]
+        public void Individual_Contains_Set(string input)
+        {
+            var collection = Individual.Set(input);
+            Assert.True(collection.Contains(input));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("foobar")]
+        [InlineData("HeLlO wOrLd")]
         public void Individual_ContainsComparer(string input)
         {
             var collection = Individual.Collection(input, StringComparer.InvariantCultureIgnoreCase);
+            Assert.True(collection.Contains(input));
+
+            if (!string.IsNullOrWhiteSpace(input))
+            {
+                Assert.True(collection.Contains(input.ToLowerInvariant()));
+                Assert.True(collection.Contains(input.ToUpperInvariant()));
+            }
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("foobar")]
+        [InlineData("HeLlO wOrLd")]
+        public void Individual_ContainsComparer_List(string input)
+        {
+            var collection = Individual.List(input, StringComparer.InvariantCultureIgnoreCase);
+            Assert.True(collection.Contains(input));
+
+            if (!string.IsNullOrWhiteSpace(input))
+            {
+                Assert.True(collection.Contains(input.ToLowerInvariant()));
+                Assert.True(collection.Contains(input.ToUpperInvariant()));
+            }
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("foobar")]
+        [InlineData("HeLlO wOrLd")]
+        public void Individual_ContainsComparer_Set(string input)
+        {
+            var collection = Individual.Set(input, StringComparer.InvariantCultureIgnoreCase);
             Assert.True(collection.Contains(input));
 
             if (!string.IsNullOrWhiteSpace(input))

--- a/BoringHelpersTests/Collections/Collection.cs
+++ b/BoringHelpersTests/Collections/Collection.cs
@@ -37,6 +37,18 @@ namespace BoringHelpersTests.Collections
         [InlineData(42)]
         public void Individual_HasOne(int input) => Assert.Single(Individual.Collection(input), input);
 
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(42)]
+        public void Individual_HasOne_Readonly(int input) => Assert.Single(Individual.ReadOnlyCollection(input), input);
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(42)]
+        public void Individual_HasOne_ReadonlyList(int input) => Assert.Single(Individual.ReadOnlyList(input), input);
+
         [Fact]
         public void Individual_CountOne() => Assert.Equal(1, Individual.Collection(0).Count);
 

--- a/BoringHelpersTests/Collections/Concat.cs
+++ b/BoringHelpersTests/Collections/Concat.cs
@@ -1,0 +1,49 @@
+﻿using Xunit;
+using System.Collections.Generic;
+using BoringHelpers.Collections;
+using System;
+
+namespace BoringHelpersTests.Collections
+{
+    public class Concat
+    {
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(42)]
+        public void Single(int input)
+        {
+            IEnumerable<int> orignal = Individual.Enumerable(input);
+            const int concatValue = -1;
+            var concat = orignal.ConcatIndividual(concatValue);
+            var expected = new List<int> { input, concatValue };
+            Assert.Equal(expected, concat);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(42)]
+        public void Single_List(int input)
+        {
+            IList<int> orignal = Individual.List(input);
+            const int concatValue = -1;
+            var concat = orignal.ConcatIndividual(concatValue);
+            var expected = new List<int> { input, concatValue };
+            Assert.Equal(expected, concat);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(42)]
+        public void Multiple(int input)
+        {
+            IEnumerable<int> orignal = Individual.Enumerable(input);
+            const int concatValue = -1;
+            var concat = orignal.ConcatIndividual(concatValue).ConcatIndividual(concatValue + 1);
+            var expected = new List<int> { input, concatValue , concatValue + 1};
+            Assert.Equal(expected, concat);
+        }
+    }
+}

--- a/BoringHelpersTests/Collections/Dictionary.cs
+++ b/BoringHelpersTests/Collections/Dictionary.cs
@@ -18,12 +18,33 @@ namespace BoringHelpersTests.Collections
         }
 
         [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(42)]
+        public void Individual_Contains_Readonly(int input)
+        {
+            var dict = Individual.ReadOnlyDictionary(input, true);
+            Assert.True(dict.ContainsKey(input));
+        }
+
+        [Theory]
         [InlineData("hello world")]
         [InlineData("HELLO WORLD")]
         [InlineData("HeLlO wOrLd")]
         public void Individual_ContainsComparer(string input)
         {
             var dict = Individual.Dictionary(input, true, StringComparer.OrdinalIgnoreCase);
+            Assert.True(dict.ContainsKey(input.ToLower()));
+            Assert.True(dict.ContainsKey(input.ToUpper()));
+        }
+
+        [Theory]
+        [InlineData("hello world")]
+        [InlineData("HELLO WORLD")]
+        [InlineData("HeLlO wOrLd")]
+        public void Individual_ContainsComparer_Readonly(string input)
+        {
+            var dict = Individual.ReadOnlyDictionary(input, true, StringComparer.OrdinalIgnoreCase);
             Assert.True(dict.ContainsKey(input.ToLower()));
             Assert.True(dict.ContainsKey(input.ToUpper()));
         }

--- a/BoringHelpersTests/Collections/Dictionary.cs
+++ b/BoringHelpersTests/Collections/Dictionary.cs
@@ -13,7 +13,7 @@ namespace BoringHelpersTests.Collections
         [InlineData(42)]
         public void Individual_Contains(int input)
         {
-            var dict = Individual.Dictionary(new KeyValuePair<int, bool>(input, true));
+            var dict = Individual.Dictionary(input, true);
             Assert.True(dict.ContainsKey(input));
         }
 
@@ -23,7 +23,7 @@ namespace BoringHelpersTests.Collections
         [InlineData("HeLlO wOrLd")]
         public void Individual_ContainsComparer(string input)
         {
-            var dict = Individual.Dictionary(new KeyValuePair<string, bool>(input, true), StringComparer.OrdinalIgnoreCase);
+            var dict = Individual.Dictionary(input, true, StringComparer.OrdinalIgnoreCase);
             Assert.True(dict.ContainsKey(input.ToLower()));
             Assert.True(dict.ContainsKey(input.ToUpper()));
         }
@@ -34,7 +34,7 @@ namespace BoringHelpersTests.Collections
         [InlineData(42)]
         public void Individual_NotContains(int input)
         {
-            var dict = Individual.Dictionary(new KeyValuePair<int, bool>(int.MaxValue, true));
+            var dict = Individual.Dictionary(int.MaxValue, true);
             Assert.False(dict.ContainsKey(input));
         }
 
@@ -44,7 +44,7 @@ namespace BoringHelpersTests.Collections
         [InlineData(42)]
         public void Individual_TryGetFound(int input)
         {
-            var dict = Individual.Dictionary(new KeyValuePair<int, bool>(input, true));
+            var dict = Individual.Dictionary(input, true);
             bool result;
             Assert.True(dict.TryGetValue(input, out result));
             Assert.True(result);
@@ -56,7 +56,7 @@ namespace BoringHelpersTests.Collections
         [InlineData(42)]
         public void Individual_TryGetNotFound(int input)
         {
-            var dict = Individual.Dictionary(new KeyValuePair<int, bool>(int.MaxValue, true));
+            var dict = Individual.Dictionary(int.MaxValue, true);
             bool result;
             Assert.False(dict.TryGetValue(input, out result));
             Assert.Equal(default(bool), result);
@@ -68,7 +68,7 @@ namespace BoringHelpersTests.Collections
         [InlineData(42)]
         public void Individual_Index(int input)
         {
-            var dict = Individual.Dictionary(new KeyValuePair<int, bool>(input, true));
+            var dict = Individual.Dictionary(input, true);
             Assert.True(dict[input]);
         }
 
@@ -78,7 +78,7 @@ namespace BoringHelpersTests.Collections
         [InlineData(42)]
         public void Individual_IndexMissing(int input)
         {
-            var dict = Individual.Dictionary(new KeyValuePair<int, bool>(int.MaxValue, true));
+            var dict = Individual.Dictionary(int.MaxValue, true);
             Assert.Throws<KeyNotFoundException>(() => dict[input]);
         }
 
@@ -88,7 +88,7 @@ namespace BoringHelpersTests.Collections
         [InlineData(42)]
         public void Individual_AddNotSupported(int input)
         {
-            var dict = Individual.Dictionary(new KeyValuePair<int, bool>(int.MaxValue, true));
+            var dict = Individual.Dictionary(int.MaxValue, true);
             Assert.Throws<NotSupportedException>(() => dict.Add(input, default));
         }
 
@@ -98,7 +98,7 @@ namespace BoringHelpersTests.Collections
         [InlineData(42)]
         public void Individual_RemoveNotSupported(int input)
         {
-            var dict = Individual.Dictionary(new KeyValuePair<int, bool>(int.MaxValue, true));
+            var dict = Individual.Dictionary(int.MaxValue, true);
             Assert.Throws<NotSupportedException>(() => dict.Remove(input));
         }
 
@@ -108,7 +108,7 @@ namespace BoringHelpersTests.Collections
         [InlineData(42)]
         public void Individual_Keys(int input)
         {
-            var dict = Individual.Dictionary(new KeyValuePair<int, bool>(input, true));
+            var dict = Individual.Dictionary(input, true);
             Assert.Single(dict.Keys, input);
         }
 
@@ -118,7 +118,7 @@ namespace BoringHelpersTests.Collections
         [InlineData(42)]
         public void Individual_Values(int input)
         {
-            var dict = Individual.Dictionary(new KeyValuePair<bool, int>(true, input));
+            var dict = Individual.Dictionary(true, input);
             Assert.Single(dict.Values, input);
         }
 

--- a/BoringHelpersTests/Collections/Enumerator.cs
+++ b/BoringHelpersTests/Collections/Enumerator.cs
@@ -7,28 +7,11 @@ namespace BoringHelpersTests.Collections
 {
     public class Enumerator
     {
-
-        [Fact]
-        public void Individual_MustMoveNext()
-        {
-            var enumerator = Individual.Enumerator<int>(default);
-            Assert.Throws<InvalidOperationException>(() => enumerator.Current);
-        }
-
         [Fact]
         public void Individual_ResetNotSupported()
         {
             var enumerator = Individual.Enumerator<int>(default);
             Assert.Throws<NotSupportedException>(enumerator.Reset);
-        }
-
-        [Fact]
-        public void Individual_ReadAfterSecondMove()
-        {
-            var enumerator = Individual.Enumerator<int>(default);
-            Assert.True(enumerator.MoveNext());
-            Assert.False(enumerator.MoveNext());
-            Assert.Throws<InvalidOperationException>(() => enumerator.Current);
         }
 
         [Theory]

--- a/BoringHelpersTests/Collections/Enumerator.cs
+++ b/BoringHelpersTests/Collections/Enumerator.cs
@@ -16,6 +16,13 @@ namespace BoringHelpersTests.Collections
         }
 
         [Fact]
+        public void Individual_ResetNotSupported()
+        {
+            var enumerator = Individual.Enumerator<int>(default);
+            Assert.Throws<NotSupportedException>(enumerator.Reset);
+        }
+
+        [Fact]
         public void Individual_ReadAfterSecondMove()
         {
             var enumerator = Individual.Enumerator<int>(default);


### PR DESCRIPTION
Breaking API changes
1. Renamed `ConcatSingle` to `ConcatIndividual`
2. Changed Dictionary signature from taking a single `KeyValue` to the `key` and `value` as independent arguments
3. Removed `comparer` as optional argument to `ReadOnlyCollection` and `ReadOnlyList`